### PR TITLE
Update ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
         otp: ["24.3.4.1", "25.0.3"]
         elixir: ["1.13.4"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
       - name: Mix dependencies cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: mix-cache
         with:
           path: |


### PR DESCRIPTION
Updates ci to use actions that are on currently-supported-by-github versions of node.