### PR TITLE
Update elixir required minimum version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,16 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ["25.2.3", "26.0"]
-        elixir: ["1.14.5"]
+        otp: ["26.2.5.9"]
+        elixir: ["1.15.8"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
       - name: Mix dependencies cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         id: mix-cache
         with:
           path: |
@@ -27,10 +27,10 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
       - run: mix deps.get
       - run: mix format --check-formatted
-        if: matrix.elixir == '1.14.5' # Only check formatting with the latest version
+        if: matrix.elixir == '1.15.8' # Only check formatting with the latest version
       - run: mix compile --warnings-as-errors
       - run: mix test
-      - run: mix credo
+      - run: MIX_ENV=dev mix credo
       - name: Run Dialyzer
         run: mix dialyzer
       - name: Install mix deps

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 25.0.3
-elixir 1.13.4-otp-25
+erlang 26.2.5.9
+elixir 1.15.8-otp-26

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Membrane.S3.Plugin.MixProject do
     [
       app: :membrane_s3_plugin,
       version: @version,
-      elixir: "~> 1.13",
+      elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env()),


### PR DESCRIPTION
The PR #29 introduced a change that requires at least Elixir 1.15.

This project's github test workflow was still depending on 1.14. There's no particular reason to prevent the upgrade.